### PR TITLE
Add support of analytics.js (GA) to switcher

### DIFF
--- a/js/all/counters-support.js
+++ b/js/all/counters-support.js
@@ -4,12 +4,21 @@
 
 $(document).on('construct', function () {
 
-    // Google Analytics
+    // Google Analytics (ga.js, legacy)
 
     //noinspection JSUnresolvedVariable
     if (typeof _gaq == 'object' && typeof _gaq.push == 'function') {
         //noinspection JSUnresolvedVariable
         _gaq.push(['_trackPageview', switcher.url]);
+    }
+    
+    // Google Analytics (analytics.js)
+    
+    //noinspection JSUnresolvedVariable
+    if (typeof ga == 'function') {
+        //noinspection JSUnresolvedVariable
+        ga('set', 'page', switcher.url);
+        ga('send', 'pageview');
     }
 
     // Yandex Metrika


### PR DESCRIPTION
Previously "switcher" only supports ga.js.
https://developers.google.com/analytics/devguides/collection/gajs/