### PR TITLE
Switcher touch fix

### DIFF
--- a/js/all/switcher.js
+++ b/js/all/switcher.js
@@ -121,11 +121,15 @@ switcher.bind = function () {
         if ($(this).hasClass('ajaxer') || $(this).hasClass('noAjaxer') || $(this).hasClass('no-switcher')) {
             return;
         }
+        
+        if (!this.hasAttribute('href')) {
+            return;
+        }
 
         var href = $(this).attr('href');
 
         // skip empty links, anchors and javascript
-        if (!href || href == '#') {
+        if (href == '' || href == '#') {
             event.preventDefault();
             return;
         }


### PR DESCRIPTION
Prevent default of "touchend" event cancels "click" event.
Problem is exists only on devices with touch interface.